### PR TITLE
Bump minimum version_requirement for Puppet

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -55,7 +55,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.2.0"
+      "version_requirement": ">= 3.8.7 < 5.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet versions