### PR TITLE
implementing suggested fix for #6 - :absent symbol is now also parsed as False

### DIFF
--- a/lib/puppet_x/util/boolean.rb
+++ b/lib/puppet_x/util/boolean.rb
@@ -12,7 +12,7 @@ module PuppetX::Util::Boolean
 
     # All values that are considered 'false' by Puppet internals
     def false_values
-      [false, 'false', :false, :no, 'no', :undef, nil]
+      [false, 'false', :false, :no, 'no', :undef, nil, :absent]
     end
 
     # Normalize Boolean values


### PR DESCRIPTION
I ran into the same voxpopuli-network bug, found #6 (from 3 years ago) and decided to implement the suggested fix.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
