### PR TITLE
Fixing error message and adding spec test

### DIFF
--- a/lib/puppet_x/util/boolean.rb
+++ b/lib/puppet_x/util/boolean.rb
@@ -28,7 +28,7 @@ module PuppetX::Util::Boolean
       elsif false_values.include? v
         false
       else
-        raise ArgumentError, "Value '#{value}':#{value.class} cannot be determined as a boolean value"
+        raise ArgumentError, "Value '#{v}':#{v.class} cannot be determined as a boolean value"
       end
     end
   end

--- a/spec/unit/puppet/property/boolean_spec.rb
+++ b/spec/unit/puppet/property/boolean_spec.rb
@@ -11,7 +11,7 @@ describe Puppet::Property::Boolean do
       subject.munge(arg).should == true
     end
   end
-  [false, :false, 'false', :no, 'no', :undef, nil].each do |arg|
+  [:absent, false, :false, 'false', :no, 'no', :undef, nil].each do |arg|
     it "should munge #{arg.inspect} as false" do
       subject.munge(arg).should == false
     end
@@ -20,5 +20,8 @@ describe Puppet::Property::Boolean do
     it "should fail to munge #{arg.inspect}" do
       expect { subject.munge(arg) }.to raise_error ArgumentError
     end
+  end
+  it "fail to munge 'woof' with a specific message" do
+    expect { subject.munge('woof') }.to raise_error ArgumentError, %r{Value 'woof':String cannot be determined as a boolean value}
   end
 end


### PR DESCRIPTION
I couldn't figure out why the actual problem in #6 was symbol :absent, but the error message was telling me it couldn't call munge() symbol :true... Turns out the error message is wrong. Fixed that, and added a spec test for :absent, and a test for the expected error message.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
